### PR TITLE
feat: 커뮤니티 댓글 등록 API 연동

### DIFF
--- a/src/pages/stock-detail/api/post-comment.ts
+++ b/src/pages/stock-detail/api/post-comment.ts
@@ -1,0 +1,16 @@
+import { httpClient } from '@/shared/api';
+import { PostComment } from './schema';
+
+export type PostCommentRequestParams = {
+  stockCode: string;
+  writerId: number;
+  parentId: string;
+  content: string;
+};
+
+export const postComment = async (
+  comment: PostCommentRequestParams
+): Promise<PostComment> => {
+  const response = await httpClient.post('/api/community', comment);
+  return PostComment.parse(response);
+};

--- a/src/pages/stock-detail/api/query.ts
+++ b/src/pages/stock-detail/api/query.ts
@@ -11,6 +11,7 @@ import {
   GetCommentRepliesRequestParams,
 } from './get-comment-replies';
 import { deleteComment } from './delete-comment';
+import { postComment, type PostCommentRequestParams } from './post-comment';
 
 export const stockFavoriteMutation = {
   like: {
@@ -65,6 +66,12 @@ export const communityQueries = {
 };
 
 export const commentMutation = {
+  post: {
+    mutationFn: (comment: PostCommentRequestParams) => postComment(comment),
+    onError: (error: Error) => {
+      alert('댓글 등록 실패 : ' + error.message);
+    },
+  },
   delete: {
     mutationFn: (commentId: string) => deleteComment(commentId),
     onError: (error: Error) => {

--- a/src/pages/stock-detail/api/schema.ts
+++ b/src/pages/stock-detail/api/schema.ts
@@ -71,3 +71,16 @@ export const CommunityResponse = z.object({
   empty: z.boolean(),
 });
 export type CommunityResponse = z.infer<typeof CommunityResponse>;
+
+export const PostComment = z.object({
+  id: z.string(),
+  writerId: z.number(),
+  writerNickname: z.string(),
+  writerImageUrl: z.string(),
+  parentId: z.string(),
+  content: z.string(),
+  liked: z.boolean(),
+  likeCount: z.number(),
+  replieCount: z.number(),
+});
+export type PostComment = z.infer<typeof PostComment>;

--- a/src/pages/stock-detail/ui/comment-base.tsx
+++ b/src/pages/stock-detail/ui/comment-base.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/shared/lib/utils.ts';
 import { Loader2 } from 'lucide-react';
 import { Comment } from '../api/schema';
 import { User } from '@/shared/api/schema.ts';
-
+import { useNavigate } from 'react-router';
 type CommentBaseProps = {
   comment: Comment;
   user?: User;
@@ -39,6 +39,8 @@ export function CommentBase({
   isFetchingMoreReplies,
   onLoadMoreReplies,
 }: CommentBaseProps) {
+  const navigate = useNavigate();
+
   // 상태 관리
   const [isLiked, setIsLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(comment.likeCount);
@@ -46,6 +48,14 @@ export function CommentBase({
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [content, setContent] = useState(comment.content);
+
+  const handleFormClick = () => {
+    if (!user) {
+      if (confirm('로그인이 필요한 서비스입니다. 로그인 하시겠습니까?')) {
+        navigate('/login');
+      }
+    }
+  };
 
   // 좋아요 버튼 처리
   const handleLikeButton = () => {
@@ -184,7 +194,12 @@ export function CommentBase({
                 placeholder={
                   user ? `댓글을 남겨보세요` : '로그인 후 댓글을 작성해보세요'
                 }
-                onSubmit={onAddReply}
+                onSubmit={(content) => {
+                  if (!user) return;
+                  onAddReply?.(content);
+                }}
+                onClick={handleFormClick}
+                disabled={!user}
               />
             </div>
           </div>

--- a/src/pages/stock-detail/ui/comment-form.tsx
+++ b/src/pages/stock-detail/ui/comment-form.tsx
@@ -6,6 +6,8 @@ type CommentFormProps = {
   rows?: number;
   onSubmit?: (content: string) => void;
   onCancel?: () => void;
+  onClick?: () => void;
+  disabled?: boolean;
 };
 
 export function CommentForm({
@@ -14,6 +16,8 @@ export function CommentForm({
   rows = 1,
   onSubmit,
   onCancel,
+  onClick,
+  disabled,
 }: CommentFormProps): JSX.Element {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -60,10 +64,10 @@ export function CommentForm({
     const formData = new FormData(form);
     const content = formData.get('content') as string;
 
-    if (content.trim() && onSubmit) {
+    if (content.trim() && onSubmit && !disabled) {
       onSubmit(content);
-      form.reset(); // 폼 초기화
-      adjustHeight(); // reset 후 높이 조절 함수 호출
+      form.reset(); // 로그인한 상태일 때만 폼 초기화
+      adjustHeight();
     }
   };
 
@@ -73,7 +77,7 @@ export function CommentForm({
       e.preventDefault();
       const content = e.currentTarget.value;
 
-      if (content.trim() && onSubmit) {
+      if (content.trim() && onSubmit && !disabled) {
         onSubmit(content);
         e.currentTarget.form?.reset();
         adjustHeight();
@@ -84,7 +88,7 @@ export function CommentForm({
   const postTextAreaId = useId();
 
   return (
-    <form method="post" onSubmit={handleSubmit}>
+    <form method="post" onSubmit={handleSubmit} onClick={onClick}>
       <label htmlFor={postTextAreaId} className="sr-only">
         댓글 작성
       </label>


### PR DESCRIPTION
- 커뮤니티 댓글/대댓글 등록 API 연동
- 비로그인 시 로그인 유도 로직 추가
  - 알림창에서 확인을 누르면 로그인 페이지로 이동
  - 비로그인 상태에서 등록 버튼을 눌러도 요청 x, 글자 사라짐 x