### PR TITLE
fix: 홈 주식 랭크 데이터 응답 오류 화면 처리

### DIFF
--- a/src/pages/home/ui/hts-top-section.tsx
+++ b/src/pages/home/ui/hts-top-section.tsx
@@ -1,0 +1,71 @@
+import { StockCard } from './stock-card';
+import { rankQueries } from '../api/query';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Skeleton } from '@/shared/ui/skeleton';
+import { RotateCw } from 'lucide-react';
+
+export function HtsTopSection() {
+  const {
+    data: htsTopRanks,
+    isLoading,
+    isError,
+    refetch,
+  } = useSuspenseQuery(rankQueries.list({ division: 'HTS_TOP' }));
+
+  if (isLoading) {
+    return (
+      <div>
+        <h2 className="mb-5 text-center text-[40px] font-bold text-[#333333]">
+          주식 TOP5
+        </h2>
+        <div className="grid grid-cols-2 gap-2">
+          <Skeleton className="col-span-2 h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || htsTopRanks.length === 0) {
+    return (
+      <div>
+        <h2 className="mb-5 text-center text-[40px] font-bold text-[#333333]">
+          주식 TOP5
+        </h2>
+        <div className="flex flex-col items-center justify-center p-4 text-neutral-500">
+          <p className="mb-4">데이터를 불러오는 데 실패했습니다.</p>
+          <button
+            className="group mt-2 rounded-full bg-neutral-500 px-4 py-4 text-white"
+            onClick={() => refetch()}
+          >
+            <RotateCw className="h-6 w-6 group-focus:[animation:spin_1s_linear_1]" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2 className="mb-5 text-center text-[40px] font-bold text-[#333333]">
+        주식 TOP5
+      </h2>
+      <div className="grid grid-cols-2 gap-2">
+        {htsTopRanks.map((rank, idx) => (
+          <StockCard
+            key={rank.stockName}
+            className={idx === 0 ? 'col-span-2' : ''}
+            rank={idx + 1}
+            name={rank.stockName}
+            price={rank.openingPrice - rank.endingPrice}
+            change={rank.prdyCtrt}
+            marketCap={rank.openingPrice}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/home/ui/market-cap-section.tsx
+++ b/src/pages/home/ui/market-cap-section.tsx
@@ -1,0 +1,71 @@
+import { StockCard } from './stock-card';
+import { rankQueries } from '../api/query';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Skeleton } from '@/shared/ui/skeleton';
+import { RotateCw } from 'lucide-react';
+
+export function MarketCapSection() {
+  const {
+    data: marketCapRanks,
+    isLoading,
+    isError,
+    refetch,
+  } = useSuspenseQuery(rankQueries.list({ division: 'MARKET_CAP' }));
+
+  if (isLoading) {
+    return (
+      <div>
+        <h2 className="mb-5 text-center text-[40px] font-bold text-[#333333]">
+          급등주
+        </h2>
+        <div className="grid grid-cols-2 gap-2">
+          <Skeleton className="col-span-2 h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || marketCapRanks.length === 0) {
+    return (
+      <div>
+        <h2 className="mb-5 text-center text-[40px] font-bold text-[#333333]">
+          급등주
+        </h2>
+        <div className="flex flex-col items-center justify-center p-4 text-neutral-500">
+          <p className="mb-4">데이터를 불러오는 데 실패했습니다.</p>
+          <button
+            className="group mt-2 rounded-full bg-neutral-500 px-4 py-4 text-white"
+            onClick={() => refetch()}
+          >
+            <RotateCw className="h-6 w-6 group-focus:[animation:spin_1s_linear_1]" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2 className="mb-5 text-center text-[40px] font-bold text-[#333333]">
+        급등주
+      </h2>
+      <div className="grid grid-cols-2 gap-2">
+        {marketCapRanks.map((rank, idx) => (
+          <StockCard
+            key={rank.stockName}
+            className={idx === 0 ? 'col-span-2' : ''}
+            rank={idx + 1}
+            name={rank.stockName}
+            price={rank.openingPrice - rank.endingPrice}
+            change={rank.prdyCtrt}
+            marketCap={rank.openingPrice}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/home/ui/market-info-section.tsx
+++ b/src/pages/home/ui/market-info-section.tsx
@@ -1,0 +1,55 @@
+import { StockCard } from './stock-card';
+
+export function MarketInfoSection() {
+  return (
+    <div>
+      <h2 className="mb-5 text-center text-[40px] font-bold text-[#333333]">
+        주요 시장 정보
+      </h2>
+      <div className="grid grid-cols-2 gap-2">
+        <StockCard
+          name="코스피"
+          nation="ko"
+          price={10000}
+          change={10}
+          marketCap={100000}
+        />
+        <StockCard
+          name="코스닥"
+          nation="ko"
+          price={10000}
+          change={10}
+          marketCap={100000}
+        />
+        <StockCard
+          name="원/달러"
+          nation="us"
+          price={10000}
+          change={10}
+          marketCap={100000}
+        />
+        <StockCard
+          name="다우존스"
+          nation="us"
+          price={10000}
+          change={10}
+          marketCap={100000}
+        />
+        <StockCard
+          name="S&P 500"
+          nation="us"
+          price={10000}
+          change={10}
+          marketCap={100000}
+        />
+        <StockCard
+          name="나스닥"
+          nation="us"
+          price={10000}
+          change={10}
+          marketCap={100000}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/home/ui/ranking-section.tsx
+++ b/src/pages/home/ui/ranking-section.tsx
@@ -1,101 +1,14 @@
-import { StockCard } from './stock-card';
-import { rankQueries } from '../api/query';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { HtsTopSection } from './hts-top-section';
+import { MarketCapSection } from './market-cap-section';
+import { MarketInfoSection } from './market-info-section';
 
 export function RankingSection() {
-  const { data: marketCapRanks } = useSuspenseQuery(
-    rankQueries.list({ division: 'MARKET_CAP' })
-  );
-  const { data: htsTopRanks } = useSuspenseQuery(
-    rankQueries.list({ division: 'HTS_TOP' })
-  );
-
   return (
     <div className="border-b border-[#d4d4d4] py-24">
       <div className="mx-auto grid max-w-5xl grid-cols-3 gap-x-2">
-        <div>
-          <h2 className="mb-5 text-center text-[40px] font-bold text-[#333333]">
-            급등주
-          </h2>
-          <div className="grid grid-cols-2 gap-2">
-            {marketCapRanks.map((rank, idx) => (
-              <StockCard
-                className={idx === 0 ? 'col-span-2' : ''}
-                rank={idx + 1}
-                name={rank.stockName}
-                price={rank.openingPrice - rank.endingPrice}
-                change={rank.prdyCtrt}
-                marketCap={rank.openingPrice}
-              />
-            ))}
-          </div>
-        </div>
-        <div>
-          <h2 className="mb-5 text-center text-[40px] font-bold text-[#333333]">
-            주식 TOP5
-          </h2>
-          <div className="grid grid-cols-2 gap-2">
-            {htsTopRanks.map((rank, idx) => (
-              <StockCard
-                className={idx === 0 ? 'col-span-2' : ''}
-                rank={idx + 1}
-                name={rank.stockName}
-                price={rank.openingPrice - rank.endingPrice}
-                change={rank.prdyCtrt}
-                marketCap={rank.openingPrice}
-              />
-            ))}
-          </div>
-        </div>
-        <div>
-          <h2 className="mb-5 text-center text-[40px] font-bold text-[#333333]">
-            주요 시장 정보
-          </h2>
-          <div className="grid grid-cols-2 gap-2">
-            <StockCard
-              name="코스피"
-              nation="ko"
-              price={10000}
-              change={10}
-              marketCap={100000}
-            />
-            <StockCard
-              name="코스닥"
-              nation="ko"
-              price={10000}
-              change={10}
-              marketCap={100000}
-            />
-            <StockCard
-              name="원/달러"
-              nation="us"
-              price={10000}
-              change={10}
-              marketCap={100000}
-            />
-            <StockCard
-              name="다우존스"
-              nation="us"
-              price={10000}
-              change={10}
-              marketCap={100000}
-            />
-            <StockCard
-              name="S&P 500"
-              nation="us"
-              price={10000}
-              change={10}
-              marketCap={100000}
-            />
-            <StockCard
-              name="나스닥"
-              nation="us"
-              price={10000}
-              change={10}
-              marketCap={100000}
-            />
-          </div>
-        </div>
+        <MarketCapSection />
+        <HtsTopSection />
+        <MarketInfoSection />
       </div>
     </div>
   );


### PR DESCRIPTION
- 홈 주식 랭크 섹션별로 컴포넌트 분리
- 실패하거나 빈배열로 응답 올 경우의 화면 문구 추가
- Add skeleton