### PR TITLE
feat: 헤더 종목분석에 AI 추천종목 코드 동적 연동

### DIFF
--- a/src/app/providers/providers.tsx
+++ b/src/app/providers/providers.tsx
@@ -2,6 +2,7 @@ import { UserProvider } from '@/shared/providers';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { NuqsAdapter } from 'nuqs/adapters/react';
+import { StockCodeProvider } from '@/shared/providers';
 
 import { type PropsWithChildren } from 'react';
 
@@ -11,7 +12,9 @@ export function Providers({ children }: PropsWithChildren) {
   return (
     <QueryClientProvider client={queryClient}>
       <NuqsAdapter>
-        <UserProvider>{children}</UserProvider>
+        <UserProvider>
+          <StockCodeProvider>{children}</StockCodeProvider>
+        </UserProvider>
       </NuqsAdapter>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/src/pages/home/ui/ai-opinion/ai-recommend-section.tsx
+++ b/src/pages/home/ui/ai-opinion/ai-recommend-section.tsx
@@ -1,8 +1,17 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { openaiQueries } from '@/entities/openai';
+import { useStockCode } from '@/shared/providers';
+import { useEffect, startTransition } from 'react';
 
 export function AiRecommendSection() {
   const { data } = useSuspenseQuery(openaiQueries.marketOpinion());
+  const { setStockCode } = useStockCode();
+
+  useEffect(() => {
+    startTransition(() => {
+      setStockCode(data.stockCode.stockCode);
+    });
+  }, [data.stockCode.stockCode, setStockCode]);
 
   return (
     <div className="border-b border-[#d4d4d4] pb-28 pt-20">

--- a/src/shared/providers/index.ts
+++ b/src/shared/providers/index.ts
@@ -1,1 +1,2 @@
 export { UserProvider, useUser } from './user-provider';
+export { StockCodeProvider, useStockCode } from './stock-code';

--- a/src/shared/providers/stock-code.tsx
+++ b/src/shared/providers/stock-code.tsx
@@ -1,0 +1,31 @@
+import {
+  createContext,
+  useContext,
+  type PropsWithChildren,
+  useState,
+} from 'react';
+
+type StockCodeContextType = {
+  stockCode: string;
+  setStockCode: (code: string) => void;
+};
+
+const StockCodeContext = createContext<StockCodeContextType | undefined>(
+  undefined
+);
+
+export function StockCodeProvider({ children }: PropsWithChildren) {
+  const [stockCode, setStockCode] = useState('035720');
+
+  return (
+    <StockCodeContext.Provider value={{ stockCode, setStockCode }}>
+      {children}
+    </StockCodeContext.Provider>
+  );
+}
+
+export function useStockCode() {
+  const context = useContext(StockCodeContext);
+  if (!context) return { stockCode: '035720', setStockCode: () => {} };
+  return context;
+}

--- a/src/shared/ui/layout.tsx
+++ b/src/shared/ui/layout.tsx
@@ -1,9 +1,10 @@
 import { Link, Outlet } from 'react-router';
 import { Avatar } from './avatar';
-import { useUser } from '../providers';
+import { useUser, useStockCode } from '../providers';
 
 export function Layout() {
   const user = useUser();
+  const { stockCode } = useStockCode();
 
   return (
     <>
@@ -22,7 +23,7 @@ export function Layout() {
             <div className="flex items-center gap-10">
               <Link
                 className="text-[18px] text-[#333333] transition-all duration-200 hover:text-[#ffb400]"
-                to="/stocks/035720"
+                to={`/stocks/${stockCode}`}
               >
                 종목분석
               </Link>


### PR DESCRIPTION
- StockCodeProvider 컨텍스트 추가
- AI 추천종목 코드를 전역 상태로 관리
- Layout의 종목분석 링크에 동적 stockCode 적용
- startTransition으로 상태 업데이트 최적화